### PR TITLE
Change mysql to mysql2 in sample mysql config

### DIFF
--- a/lib/proto/thoth.conf.sample
+++ b/lib/proto/thoth.conf.sample
@@ -18,7 +18,7 @@ live:
   #   db: sqlite:////absolute/path/to/database.db
   #
   # Sample MySQL config:
-  #   db: mysql://user:pass@hostname/database
+  #   db: mysql2://user:pass@hostname/database
   db: sqlite:///<%= Thoth::HOME_DIR %>/db/live.db
 
   # General site settings.


### PR DESCRIPTION
There was a small issue. 
If I use the conf file as is with mysql I get this
![screenshot from 2017-07-03 21-42-03](https://user-images.githubusercontent.com/17255848/27804644-ad24688a-6038-11e7-9fe0-fb6b32818ff7.png)
By changing 
`db: mysql://user:pass@hostname/database`
to
`db: mysql2://user:pass@hostname/database`
I get the errors specified [here](https://github.com/pagojo/rethoth/issues/1) so it now sees MySQL correctly.
Check if this is the case with you too.