### PR TITLE
Make rethoth play well with the default MySQL/MariaDB config

### DIFF
--- a/lib/thoth/migrate/001_create_schema.rb
+++ b/lib/thoth/migrate/001_create_schema.rb
@@ -28,7 +28,7 @@
 
 class CreateSchema < Sequel::Migration
   def down
-    drop_table :tags_posts_map, :comments, :media, :pages, :posts, :tags 
+    drop_table :tags_posts_map, :comments, :media, :pages, :posts, :tags
   end
 
   def up
@@ -52,8 +52,8 @@ class CreateSchema < Sequel::Migration
         varchar  :author,        :null => false
         varchar  :author_url
         varchar  :title,         :null => false
-        text     :body,          :default => ''
-        text     :body_rendered, :default => ''
+        text     :body
+        text     :body_rendered
         varchar  :ip
         datetime :created_at,    :null => false
         datetime :updated_at,    :null => false


### PR DESCRIPTION
This fixes the issue I described in my latest comments [here](https://github.com/pagojo/rethoth/issues/3).

MySQL threw a `Mysql2::Error: BLOB, TEXT, GEOMETRY or JSON column 'body' can't have a default value` error. 

With little research, I found out that this is a very common issue. 

I removed the default value of basically nothing that `:default => ''` gave the `body` and `body_rendered` attributes and now I get a very nice `Migration Complete.` message when running `thoth --migrate`.

Tested it and it works. :)